### PR TITLE
Global Saving Action

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 .sissi
 .sthash
+/build
 /config.json
 /content.json
 /content.json.backup

--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@
 /.eslintrc
 /.sissi
 /.sthash
+/build
 /config.json
 /content.json
 /content.json.backup

--- a/src/actions/request/creators.js
+++ b/src/actions/request/creators.js
@@ -28,19 +28,26 @@ export const fetchData = dataType => {
   return action;
 }
 
-export const postContent = () => (dispatch, getState, selectFormNames = getFormNames) => {
+export const postContent = buildAfter => (dispatch, getState, selectFormNames = getFormNames) => {
   const allFormNames = selectFormNames()(getState()) || [];
   const formName = allFormNames[0];
 
-  dispatch({
+  const action = {
     type: t.SEND_REQUEST,
     payload: {
       method: k.POST,
       dataType: k.CONTENT,
       formName,
-      onSuccess: [dispatch => dispatch(setAlert(k.SUCCESS, tr.SUCCESS_SAVE))],
+      onSuccess: [],
     },
-  });
+  };
+  if (buildAfter) {
+    action.payload.onSuccess.push(dispatch => dispatch(buildPage()));
+  } else {
+    action.payload.onSuccess.push(dispatch => dispatch(setAlert(k.SUCCESS, tr.SUCCESS_SAVE)));
+  }
+
+  dispatch(action);
 };
 
 export const buildPage = () => ({

--- a/src/actions/request/creators.js
+++ b/src/actions/request/creators.js
@@ -1,4 +1,7 @@
-import { getFormValues } from 'redux-form';
+import {
+  getFormNames,
+  getFormValues,
+} from 'redux-form';
 
 import {
   setAlert,
@@ -25,15 +28,20 @@ export const fetchData = dataType => {
   return action;
 }
 
-export const postContent = formName => ({
-  type: t.SEND_REQUEST,
-  payload: {
-    method: k.POST,
-    dataType: k.CONTENT,
-    formName,
-    onSuccess: [dispatch => dispatch(setAlert(k.SUCCESS, tr.SUCCESS_SAVE))],
-  },
-});
+export const postContent = () => (dispatch, getState, selectFormNames = getFormNames) => {
+  const allFormNames = selectFormNames()(getState()) || [];
+  const formName = allFormNames[0];
+
+  dispatch({
+    type: t.SEND_REQUEST,
+    payload: {
+      method: k.POST,
+      dataType: k.CONTENT,
+      formName,
+      onSuccess: [dispatch => dispatch(setAlert(k.SUCCESS, tr.SUCCESS_SAVE))],
+    },
+  });
+};
 
 export const buildPage = () => ({
   type: t.SEND_REQUEST,

--- a/src/actions/request/creators.test.js
+++ b/src/actions/request/creators.test.js
@@ -13,13 +13,21 @@ describe('actions/request', () => {
   });
 
   describe('postContent', () => {
-    it('should dispatch an action with the correct type and payload', () => {
-      const action = actions.postContent('test');
+    it('should return a thunk that dispatches the correct action', () => {
+      const mockDispatch = jest.fn();
+      const mockGetState = jest.fn();
+      const mockGetFormNames = jest.fn(() => () => ['myForm']);
+      const thunk = actions.postContent();
+      thunk(mockDispatch, mockGetState, mockGetFormNames);
+
+      expect(mockDispatch.mock.calls).toHaveLength(1);
+
+      const action = mockDispatch.mock.calls[0][0]
 
       expect(action).toHaveProperty('type', t.SEND_REQUEST);
       expect(action.payload).toHaveProperty('method', 'post');
       expect(action.payload).toHaveProperty('dataType', 'content');
-      expect(action.payload).toHaveProperty('formName', 'test');
+      expect(action.payload).toHaveProperty('formName', 'myForm');
       expect(action.payload).toHaveProperty('onSuccess');
     });
   });

--- a/src/actions/ui/creators.js
+++ b/src/actions/ui/creators.js
@@ -1,20 +1,30 @@
 import * as t from '@/actions/types';
-import { ERROR } from '@/constants';
+import * as k from '@/constants';
 import * as tr from '@/translations';
 
-export const clearAlerts = () => ({
+export const clearAlerts = (isConfirmed = false) => ({
   type: t.CLEAR_ALERTS,
+  payload: { isConfirmed },
 });
 
-export const setAlert = (type, message, trData) => ({
-  type: t.SET_ALERT,
-  payload: {
-    message,
-    title: type === ERROR ? tr.ERROR : tr.SUCCESS,
-    type,
-    trData,
-  },
-});
+export const setAlert = (type, message, trData, allowCancel) => {
+  const title = {
+    [k.ERROR]: tr.ERROR,
+    [k.SUCCESS]: tr.SUCCESS,
+    [k.NEUTRAL]: tr.NEUTRAL,
+  }[type] || tr.SUCCESS;
+
+  return {
+    type: t.SET_ALERT,
+    payload: {
+      message,
+      title,
+      type,
+      trData,
+      allowCancel,
+    },
+  };
+};
 
 export const activateLoading = () => ({
   type: t.SET_LOADING,

--- a/src/actions/ui/creators.test.js
+++ b/src/actions/ui/creators.test.js
@@ -7,9 +7,10 @@ import * as actions from './creators';
 describe('actions/ui', () => {
   describe('clearAlerts', () => {
     it('should dispatch an action with the correct type', () => {
-      const action = actions.clearAlerts();
+      const action = actions.clearAlerts(true);
 
       expect(action).toHaveProperty('type', t.CLEAR_ALERTS);
+      expect(action.payload).toHaveProperty('isConfirmed', true);
     });
   });
 

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -12,7 +12,7 @@ const mapStateToProps = state => ({
   ...selectors.getPropsForAlert(state),
 });
 
-const mapDispatchToProps = (dispatch) => ({
+const mapDispatchToProps = dispatch => ({
   onConfirm: () => dispatch(actions.clearAlerts()),
 });
 

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -31,16 +31,24 @@ const Alert = ({
     <article className={`modal__box modal__box--alert ${type}`}>
       <h2 className='modal__title'><Translate id={title} /></h2>
       <p className='modal__message'><Translate id={message} data={trData} /></p>
-      {allowConfirm && (
-        <C.Button onClick={onConfirm}>
-          <Translate id={tr.OK} />
-        </C.Button>
-      )}
-      {allowCancel && (
-        <C.Button onClick={onCancel}>
-          <Translate id={tr.CANCEL} />
-        </C.Button>
-      )}
+      <div className='modal__button-row'>
+        {allowConfirm && (
+          <C.Button
+            classes={`${allowCancel ? '' : 'button--cta'} ${type}`}
+            onClick={onConfirm}
+          >
+            <Translate id={tr.OK} />
+          </C.Button>
+        )}
+        {allowCancel && (
+          <C.Button
+            classes={`button--cta ${type}`}
+            onClick={onCancel}
+          >
+            <Translate id={tr.CANCEL} />
+          </C.Button>
+        )}
+      </div>
     </article>
   </aside>
 );

--- a/src/components/Alert.js
+++ b/src/components/Alert.js
@@ -13,15 +13,18 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  onConfirm: () => dispatch(actions.clearAlerts()),
+  onConfirm: () => dispatch(actions.clearAlerts(true)),
+  onCancel: () => dispatch(actions.clearAlerts(false)),
 });
 
 const Alert = ({
+  allowCancel,
   allowConfirm,
   message,
   title,
   trData,
   type,
+  onCancel,
   onConfirm,
 }) => !!type && (
   <aside className='modal modal--alert'>
@@ -33,16 +36,23 @@ const Alert = ({
           <Translate id={tr.OK} />
         </C.Button>
       )}
+      {allowCancel && (
+        <C.Button onClick={onCancel}>
+          <Translate id={tr.CANCEL} />
+        </C.Button>
+      )}
     </article>
   </aside>
 );
 
 Alert.propTypes = {
+  allowCancel: PropTypes.bool,
   allowConfirm: PropTypes.bool,
   message: PropTypes.string,
   title: PropTypes.string,
   trData: PropTypes.object,
   type: PropTypes.string,
+  onCancel: PropTypes.func,
   onConfirm: PropTypes.func,
 };
 

--- a/src/components/actionbar/ActionBar.js
+++ b/src/components/actionbar/ActionBar.js
@@ -18,7 +18,7 @@ const mapDispatchToProps = dispatch => ({
     dispatch(actions.resetSession());
     dispatch(actions.redirectToLogin());
   },
-  onPublish: () => dispatch(actions.buildPage()),
+  onPublish: () => dispatch(actions.postContent(true)),
   onSave: () => dispatch(actions.postContent()),
 });
 

--- a/src/components/actionbar/ActionBar.js
+++ b/src/components/actionbar/ActionBar.js
@@ -19,16 +19,22 @@ const mapDispatchToProps = dispatch => ({
     dispatch(actions.redirectToLogin());
   },
   onPublish: () => dispatch(actions.buildPage()),
+  onSave: () => dispatch(actions.postContent()),
 });
 
 const ActionBar = ({
   isIndex,
   onLogout,
   onPublish,
+  onSave,
 }) => (
   <aside className='actionbar'>
     <C.Button classes='button--cta' onClick={onPublish} >
       <Translate id={tr.PUBLISH} />
+    </C.Button>
+
+    <C.Button onClick={onSave} >
+      <Translate id={tr.SAVE} />
     </C.Button>
 
     <C.Button onClick={onLogout}>
@@ -48,6 +54,7 @@ ActionBar.propTypes = {
   isIndex: PropTypes.bool,
   onLogout: PropTypes.func,
   onPublish: PropTypes.func,
+  onSave: PropTypes.func,
 };
 
 export default connect(mapStateToProps, mapDispatchToProps)(ActionBar);

--- a/src/components/form/Form.js
+++ b/src/components/form/Form.js
@@ -9,9 +9,9 @@ import * as actions from '@/actions';
 import * as C from '@/components';
 import * as tr from '@/translations';
 
-const mapDispatchToProps = (dispatch, ownProps) => ({
+const mapDispatchToProps = dispatch => ({
   onDelete: () => dispatch(actions.deleteItem()),
-  onSave: () => dispatch(actions.postContent(ownProps.form)),
+  onSave: () => dispatch(actions.postContent()),
 });
 
 const Form = ({

--- a/src/constants/keywords.js
+++ b/src/constants/keywords.js
@@ -25,6 +25,7 @@ export const TEXT = 'text';
 export const ERROR = 'error';
 export const LOADING = 'loading';
 export const SUCCESS = 'success';
+export const NEUTRAL = 'neutral';
 
 /* MODAL TYPES */
 export const GUIDE = 'guide';

--- a/src/middleware/index.js
+++ b/src/middleware/index.js
@@ -1,5 +1,6 @@
 // gatherRequestData not exported with other middlewares to make sure it is executed first
 export { default as fieldLists } from './fieldLists';
+export { default as interruptRoute } from './interruptRoute';
 export { default as localStorage } from './localStorage';
 export { default as pages } from './pages';
 export { default as sections } from './sections';

--- a/src/middleware/interruptRoute.js
+++ b/src/middleware/interruptRoute.js
@@ -1,0 +1,27 @@
+import {
+  getFormNames,
+  isDirty,
+} from 'redux-form';
+
+import * as k from '@/constants/keywords';
+import * as routes from '@/router';
+
+export default store => next => action => {
+  if ([
+    routes.ROUTE_INDEX,
+    routes.ROUTE_PAGE,
+    routes.ROUTE_SECTION,
+  ].includes(action.type)) {
+
+    const allFormNames = getFormNames()(store.getState()) || [];
+    const formName = allFormNames[0];
+    const isFormDirty = isDirty(formName)(store.getState());
+
+    if (isFormDirty && formName !== k.LOGIN) {
+      console.log('dirty changes');
+      return;
+    }
+  }
+
+  next(action);
+}

--- a/src/middleware/interruptRoute.js
+++ b/src/middleware/interruptRoute.js
@@ -12,16 +12,16 @@ import * as tr from '@/translations/alerts';
 let listenForAlerts = false;
 let interruptedAction = null;
 
-export default store => next => action => {
+export default (store, formSelectors = { getFormNames, isDirty }) => next => action => {
   if ([
     routes.ROUTE_INDEX,
     routes.ROUTE_PAGE,
     routes.ROUTE_SECTION,
   ].includes(action.type)) {
 
-    const allFormNames = getFormNames()(store.getState()) || [];
+    const allFormNames = formSelectors.getFormNames()(store.getState()) || [];
     const formName = allFormNames[0];
-    const isFormDirty = isDirty(formName)(store.getState());
+    const isFormDirty = formSelectors.isDirty(formName)(store.getState());
 
     if (isFormDirty && formName !== k.LOGIN) {
       listenForAlerts = true;

--- a/src/middleware/interruptRoute.test.js
+++ b/src/middleware/interruptRoute.test.js
@@ -1,0 +1,102 @@
+import * as t from '@/actions/types';
+import { ROUTE_PAGE } from '@/router';
+
+import middleware from './interruptRoute';
+
+describe('middleware/interruptRoute', () => {
+  let mockAction, mockStore, mockNext, mockSelectors;
+
+  beforeEach(() => {
+    mockNext = jest.fn();
+    mockStore = {
+      getState: jest.fn(),
+      dispatch: jest.fn(),
+    };
+    mockSelectors = {
+      getFormNames: jest.fn(() =>() => ['myForm']),
+      isDirty: jest.fn(() => () => true),
+    };
+  })
+
+  it('should forward the action if the type is not SEND_REQUEST', () => {
+    mockAction = { type: 'test' };
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+
+    expect(mockNext).toBeCalledWith(mockAction);
+  });
+
+  it('should not forward route changes with dirty forms', () => {
+    mockAction = {
+      type: ROUTE_PAGE,
+    };
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+
+    expect(mockNext).not.toBeCalled();
+  });
+
+  it('should forward route changes with clean forms', () => {
+    mockAction = {
+      type: ROUTE_PAGE,
+    };
+    mockSelectors.isDirty = jest.fn(() => () => false);
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+
+    expect(mockNext).toBeCalledWith(mockAction);
+  });
+
+  it('should forward route changes with dirty forms if it is the login form', () => {
+    mockAction = {
+      type: ROUTE_PAGE,
+    };
+    mockSelectors.getFormNames = jest.fn(() => () => ['login']);
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+
+    expect(mockNext).toBeCalledWith(mockAction);
+  });
+
+  it('should dispatch an alert for dirty forms', () => {
+    mockAction = {
+      type: ROUTE_PAGE,
+    };
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+    expect(mockStore.dispatch).toBeCalled();
+
+    const action = mockStore.dispatch.mock.calls[0][0];
+    expect(action).toHaveProperty('type', t.SET_ALERT);
+  });
+
+  it('should forward the interrupted action if the alert is confirmed', () => {
+    mockAction = {
+      type: ROUTE_PAGE,
+    };
+    const confirmAction = {
+      type: t.CLEAR_ALERTS,
+      payload: { isConfirmed: true },
+    };
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+    middleware(mockStore, mockSelectors)(mockNext)(confirmAction);
+
+    expect(mockNext).toBeCalledWith(mockAction);
+  });
+
+  it('should not forward the interrupted action if the alert is not confirmed', () => {
+    mockAction = {
+      type: ROUTE_PAGE,
+    };
+    const confirmAction = {
+      type: t.CLEAR_ALERTS,
+      payload: { isConfirmed: false },
+    };
+
+    middleware(mockStore, mockSelectors)(mockNext)(mockAction);
+    middleware(mockStore, mockSelectors)(mockNext)(confirmAction);
+
+    expect(mockNext).not.toBeCalledWith(mockAction);
+  });
+});

--- a/src/reducers/ui/alert.js
+++ b/src/reducers/ui/alert.js
@@ -1,6 +1,7 @@
 import * as t from '@/actions/types';
 
 const initialState = {
+  allowCancel: false,
   type: '',
   message: '',
   title: '',

--- a/src/router/options.js
+++ b/src/router/options.js
@@ -1,8 +1,3 @@
-import {
-  getFormNames,
-  isDirty,
-} from 'redux-form';
-
 import * as actions from '@/actions';
 import * as k from '@/constants/keywords';
 import * as selectors from '@/selectors';
@@ -14,9 +9,6 @@ export default {
     const isLoggedIn = selectors.getAuthToken(getState()) !== null;
     const isNavigatingToLogin = action.type === routes.ROUTE_LOGIN;
     const isInitialDataFetched = selectors.getIsInitialDataFetched(getState());
-    const allFormNames = getFormNames()(getState()) || [];
-    const formName = allFormNames[0];
-    const isFormDirty = isDirty(formName)(getState());
 
     if (!isLoggedIn) {
       if (!isNavigatingToLogin) {
@@ -24,10 +16,6 @@ export default {
       }
 
     } else {
-      if (isFormDirty && formName !== k.LOGIN) {
-        // trigger modal
-      }
-
       if (isNavigatingToLogin) {
         return dispatch(actions.redirectToIndex());
       }

--- a/src/router/options.js
+++ b/src/router/options.js
@@ -1,3 +1,8 @@
+import {
+  getFormNames,
+  isDirty,
+} from 'redux-form';
+
 import * as actions from '@/actions';
 import * as k from '@/constants/keywords';
 import * as selectors from '@/selectors';
@@ -9,6 +14,9 @@ export default {
     const isLoggedIn = selectors.getAuthToken(getState()) !== null;
     const isNavigatingToLogin = action.type === routes.ROUTE_LOGIN;
     const isInitialDataFetched = selectors.getIsInitialDataFetched(getState());
+    const allFormNames = getFormNames()(getState()) || [];
+    const formName = allFormNames[0];
+    const isFormDirty = isDirty(formName)(getState());
 
     if (!isLoggedIn) {
       if (!isNavigatingToLogin) {
@@ -16,6 +24,10 @@ export default {
       }
 
     } else {
+      if (isFormDirty && formName !== k.LOGIN) {
+        // trigger modal
+      }
+
       if (isNavigatingToLogin) {
         return dispatch(actions.redirectToIndex());
       }

--- a/src/styles/_modifier.scss
+++ b/src/styles/_modifier.scss
@@ -28,6 +28,21 @@
   }
 }
 
+.neutral {
+  color: $color-main-dark;
+  border-color: $color-main-dark;
+
+  .button {
+    color: $color-background;
+    background-color: $color-main-dark;
+
+    &:hover {
+      border: none;
+      background-color: $color-success;
+    }
+  }
+}
+
 .placeholder {
   display: flex;
   flex-direction: column;

--- a/src/styles/modal.scss
+++ b/src/styles/modal.scss
@@ -36,6 +36,7 @@
   align-items: center;
 
   min-height: 30%;
+  min-width: (2 * $button-width) + (2 * $gap-wide);
   height: auto;
   width: 40%;
 
@@ -125,25 +126,19 @@
   line-height: 1.4;
 }
 
-.modal__button {
-  height: 40px;
-  width: 40%;
-  margin: 0;
-  color: $color-background;
-  background-color: $color-main-dark;
-  font-size: $font-size-normal;
-  cursor: pointer;
+.modal__button-row {
+  display: flex;
+  flex-direction: row;
 
-  &--loading {
-    display: none;
-  }
+  .button {
+    &:not(.button--cta):not(:hover) {
+      color: inherit;
+      background-color: $color-white;
+    }
 
-  &--error {
-    background-color: $color-error;
-  }
-
-  &--success {
-    background-color: $color-success;
+    &:not(:last-child) {
+      margin-right: $gap-tiny;
+    }
   }
 }
 

--- a/src/translations/alerts.js
+++ b/src/translations/alerts.js
@@ -1,3 +1,4 @@
+export const CONFIRM_DISCARD = 'translations/modal/confirmDiscard';
 export const ERROR = 'translations/modal/error';
 export const ERROR_AUTH = 'translations/modal/errorAuth';
 export const ERROR_BUILD = 'translations/modal/errorBuild';
@@ -7,11 +8,16 @@ export const ERROR_LOGIN = 'translations/modal/errorLogin';
 export const ERROR_SERVER = 'translations/modal/errorServer';
 export const LOADING = 'translations/modal/loading';
 export const LOADING_TEXT = 'translations/modal/loadingText';
+export const NEUTRAL = 'translations/modal/neutral';
 export const SUCCESS = 'translations/modal/success';
 export const SUCCESS_PUBLISH = 'translations/modal/successPublish';
 export const SUCCESS_SAVE = 'translations/modal/successSave';
 
 export default {
+  [CONFIRM_DISCARD]: [
+    "If you leave this form without saving all your changes will be discarded.",
+    "Wenn du dieses Formular verlässt, ohne zu speichern, werden deine Änderungen verworfen.",
+  ],
   [ERROR]: [
     "Error",
     "Ohje..."
@@ -47,6 +53,10 @@ export default {
   [LOADING_TEXT]: [
     "Magic is happening...",
     "Gleich ist es soweit..."
+  ],
+  [NEUTRAL]: [
+    "Please note",
+    "Achtung",
   ],
   [SUCCESS]: [
     "Success",

--- a/src/translations/alerts.js
+++ b/src/translations/alerts.js
@@ -20,23 +20,23 @@ export default {
   ],
   [ERROR]: [
     "Error",
-    "Ohje..."
+    "Ohje...",
   ],
   [ERROR_AUTH]: [
     "You have been logged out. Please login again with your username and password.",
-    "Du wurdest ausgeloggt. Bitte melde dich erneut mit Nutzername und Passwort an."
+    "Du wurdest ausgeloggt. Bitte melde dich erneut mit Nutzername und Passwort an.",
   ],
   [ERROR_BUILD]: [
     "Something went wrong while publishing your page. Please try again! If this keeps happening contact your developer",
-    "Beim Veröffentlichen der Seite ist etwas schiefgelaufen. Bitte versuch es nochmal! Falls das nicht funktioniert, kontaktiere deinen Website-Entwickler."
+    "Beim Veröffentlichen der Seite ist etwas schiefgelaufen. Bitte versuch es nochmal! Falls das nicht funktioniert, kontaktiere deinen Website-Entwickler.",
   ],
   [ERROR_IMAGE_SIZE]: [
     "The maximum file size is 500 KB. Please select a smaller image.",
-    "Die maximale Dateigröße ist 500 KB. Bitte wähle ein kleineres Bild aus"
+    "Die maximale Dateigröße ist 500 KB. Bitte wähle ein kleineres Bild aus",
   ],
   [ERROR_IMAGE_TYPE]: [
     "Sorry, this file type is not valid. Please select an image.",
-    "Dieses Format ist ungültig. Bitte wähle ein Bild aus."
+    "Dieses Format ist ungültig. Bitte wähle ein Bild aus.",
   ],
   [ERROR_LOGIN]: [
     "Sorry, the username or password you entered was not found.",
@@ -44,15 +44,15 @@ export default {
   ],
   [ERROR_SERVER]: [
     "The server is not responding. Please try to reload the page! If this keeps happening contact your developer.",
-    "Der Server ist nicht erreichbar. Bitte lade die Seite neu! Falls das nicht funktioniert, kontaktiere  deinen Website-Entwickler."
+    "Der Server ist nicht erreichbar. Bitte lade die Seite neu! Falls das nicht funktioniert, kontaktiere  deinen Website-Entwickler.",
   ],
   [LOADING]: [
     "Loading",
-    "Einen Moment"
+    "Einen Moment",
   ],
   [LOADING_TEXT]: [
     "Magic is happening...",
-    "Gleich ist es soweit..."
+    "Gleich ist es soweit...",
   ],
   [NEUTRAL]: [
     "Please note",
@@ -60,14 +60,14 @@ export default {
   ],
   [SUCCESS]: [
     "Success",
-    "Juhuu!"
+    "Juhuu!",
   ],
   [SUCCESS_PUBLISH]: [
     "All changes published!",
-    "Die neuen Inhalte sind online."
+    "Die neuen Inhalte sind online.",
   ],
   [SUCCESS_SAVE]: [
     "We saved your changes!",
-    "Alle Änderungen gespeichert."
+    "Alle Änderungen gespeichert.",
   ],
 };

--- a/src/translations/buttons.js
+++ b/src/translations/buttons.js
@@ -1,5 +1,6 @@
 export const ADD = 'translations/buttons/add';
 export const ADD_DATA = 'translations/buttons/add_data';
+export const CANCEL = 'translations/buttons/cancel';
 export const DELETE = 'translations/buttons/delete';
 export const LOGIN = 'translations/buttons/login';
 export const LOGOUT = 'translations/buttons/logout';
@@ -17,6 +18,10 @@ export default {
     "Add ${data}",
     "${data} hinzufügen",
     /* eslint-enable no-template-curly-in-string */
+  ],
+  [CANCEL]: [
+    "Cancel",
+    "Abbrechen",
   ],
   [DELETE]: [
     "Delete",


### PR DESCRIPTION
New features to test:
- [x] `publishContent` is now an action that can be called from anywhere in the app
- [x] A `save`-button is added to the ActionBar
- [x] The content is saved before publishing
- [x] Styles for neutral modals have been added
- [x] Modals can contain both OK and cancel buttons with `cta` always on cancel if it exists
- [x] A modal pops up if a route change is attempted with a dirty form (new middleware)
- [x] If the modal is confirmed the changes get discarded and the route change runs through
- [x] Otherwise the route change will not proceed